### PR TITLE
android orientation wip

### DIFF
--- a/android/src/main/java/com/bendyworks/capML/CapML.java
+++ b/android/src/main/java/com/bendyworks/capML/CapML.java
@@ -28,7 +28,7 @@ public class CapML extends Plugin {
       Uri uri = Uri.fromFile(file);
 
       TextDetector td = new TextDetector();
-      td.detectText(call, this.getContext(), uri, 0);
+      td.detectText(call, this.getContext(), uri, 270);
     } else {
       call.reject("File not found");
       return;

--- a/android/src/main/java/com/bendyworks/capML/TextDetector.kt
+++ b/android/src/main/java/com/bendyworks/capML/TextDetector.kt
@@ -1,17 +1,30 @@
 package com.bendyworks.capML
 
-import com.getcapacitor.PluginCall
-import com.getcapacitor.JSObject
-
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.Rect
 import android.net.Uri
+import android.provider.MediaStore
 import android.util.NoSuchPropertyException
+import com.getcapacitor.JSObject
+import com.getcapacitor.PluginCall
 import com.google.firebase.ml.vision.FirebaseVision
 import com.google.firebase.ml.vision.common.FirebaseVisionImage
+import com.google.firebase.ml.vision.common.FirebaseVisionImageMetadata
 import com.google.firebase.ml.vision.text.FirebaseVisionTextRecognizer
 import org.json.JSONArray
-import kotlin.collections.ArrayList
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.nio.ByteBuffer
+import android.R.attr.bitmap
+import android.graphics.BitmapFactory
+
+import android.opengl.ETC1.getHeight
+
+import android.opengl.ETC1.getWidth
+
+
 
 
 class TextDetector {
@@ -19,14 +32,46 @@ class TextDetector {
     val image: FirebaseVisionImage
     val detectedText = ArrayList<Any>()
 
+    val imageRotation = degreesToFirebaseRotation(degrees)
+//    val bitmap: Bitmap = MediaStore.Images.Media.getBitmap(context.contentResolver, fileUri)
+//    val bitmap = BitmapFactory.decodeFile(fileUri.toString());
+//
+//    println("bitmap:")
+//    println(bitmap.byteCount)
+
+
+//    println("scale" + scaleX + ":" + scaleY)
+//
+//    val size: Int = bitmap.getRowBytes() * bitmap.getHeight()
+//    println("size with rowbytes:"+ bitmap.getRowBytes() + ":" + bitmap.getHeight())
+//    println("size with getWidth:" + bitmap.getWidth() + ":" + bitmap.getHeight())
+//    val byteBuffer: ByteBuffer = ByteBuffer.allocate(size)
+//    bitmap.copyPixelsToBuffer(byteBuffer)
+//    val byteArray = byteBuffer.array()
+
+    val tempImage = FirebaseVisionImage.fromFilePath(context, fileUri)
+    val bitmap = tempImage.bitmap
+    bitmap.
+    val byteArray = bitmap.convertToByteArray()
+
+    val scaleX = 480// 480x360 is typically sufficient for
+    val scaleY = 360// image recognition
+
+    val metadata = FirebaseVisionImageMetadata.Builder()
+      .setWidth(480)
+      .setHeight(360)
+      .setFormat(FirebaseVisionImageMetadata.IMAGE_FORMAT_NV21)  // YCrCb format used for images, which uses the NV21 encoding format.
+      .setRotation(FirebaseVisionImageMetadata.ROTATION_0)
+      .build()
+
+    println("size:" + bitmap.getRowBytes() + ":" + bitmap.getHeight())
+    println("byteArray:" + byteArray)
+    println("byteArray:" + byteArray.size)
+//{topLeft=[0.24166666666666667, 0.79], topRight=[0.25833333333333336, 0.79], bottomLeft=[0.24166666666666667, 0.7883333333333333], bottomRight=[0.25833333333333336, 0.7883333333333333], text=--}
     try {
-      image = FirebaseVisionImage.fromFilePath(context, fileUri)
-
-      // getting the height and width of the image to perform scaling
-      val bitmap = image.getBitmap()
-      val width = bitmap.getWidth()
-      val height = bitmap.getHeight()
-
+//      image = FirebaseVisionImage.fromBitmap(bitmap);
+       image = FirebaseVisionImage.fromByteArray(byteArray, metadata)
+//      val image = FirebaseVisionImage.fromFilePath(context, fileUri)
       val textDetector: FirebaseVisionTextRecognizer = FirebaseVision.getInstance().getOnDeviceTextRecognizer();
 
       textDetector.processImage(image)
@@ -37,18 +82,21 @@ class TextDetector {
 
               val textDetection = mapOf(
                 // normalizing coordinates
-                "topLeft" to listOf<Double?>((rect.left).toDouble()/width, (height - rect.top).toDouble()/height),
-                "topRight" to listOf<Double?>((rect.right).toDouble()/width, (height - rect.top).toDouble()/height),
-                "bottomLeft" to listOf<Double?>((rect.left).toDouble()/width, (height - rect.bottom).toDouble()/height),
-                "bottomRight" to listOf<Double?>((rect.right).toDouble()/width, (height - rect.bottom).toDouble()/height),
+                "topLeft" to listOf<Double?>((rect.left).toDouble()/scaleX, (scaleY - rect.top).toDouble()/scaleY),
+                "topRight" to listOf<Double?>((rect.right).toDouble()/scaleX, (scaleY - rect.top).toDouble()/scaleY),
+                "bottomLeft" to listOf<Double?>((rect.left).toDouble()/scaleX, (scaleY - rect.bottom).toDouble()/scaleY),
+                "bottomRight" to listOf<Double?>((rect.right).toDouble()/scaleX, (scaleY - rect.bottom).toDouble()/scaleY),
                 "text" to line.text
               )
+              println("text detection:")
+              println(textDetection)
               detectedText.add(textDetection)
             }
           }
           call.success(JSObject().put("textDetections", JSONArray(detectedText)))
         }
         .addOnFailureListener { e ->
+          println("error error error")
           call.reject("FirebaseVisionTextRecognizer couldn't process the given image", e)
         }
     } catch (e: Exception) {
@@ -56,4 +104,34 @@ class TextDetector {
       call.reject(e.localizedMessage, e)
     }
   }
+
+  private fun degreesToFirebaseRotation(degrees: Int): Int = when(degrees) {
+    0 -> FirebaseVisionImageMetadata.ROTATION_0
+    90 -> FirebaseVisionImageMetadata.ROTATION_90
+    180 -> FirebaseVisionImageMetadata.ROTATION_180
+    270 -> FirebaseVisionImageMetadata.ROTATION_270
+    else -> throw Exception("Rotation must be 0, 90, 180, or 270.")
+  }
+}
+
+@Throws(IOException::class)
+fun Bitmap.convertToByteArray(): ByteArray {
+  //minimum number of bytes that can be used to store this bitmap's pixels
+  val size = this.byteCount
+
+  //allocate new instances which will hold bitmap
+  val buffer = ByteBuffer.allocate(size)
+  val bytes = ByteArray(size)
+
+  //copy the bitmap's pixels into the specified buffer
+  this.copyPixelsToBuffer(buffer)
+
+  //rewinds buffer (buffer position is set to zero and the mark is discarded)
+  buffer.rewind()
+
+  //transfer bytes from buffer into the given destination array
+  buffer.get(bytes)
+
+  //return bitmap's pixels
+  return bytes
 }

--- a/examples/text-detection/ImageReader/android/app/build.gradle
+++ b/examples/text-detection/ImageReader/android/app/build.gradle
@@ -39,8 +39,6 @@ dependencies {
   androidTestImplementation 'androidx.test.ext:junit:1.1.1'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     implementation project(':capacitor-cordova-android-plugins')
-  implementation 'com.google.firebase:firebase-analytics:17.2.3'
-  implementation 'com.google.firebase:firebase-ml-vision:24.0.1'
   implementation 'androidx.core:core-ktx:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/examples/text-detection/ImageReader/android/app/src/main/AndroidManifest.xml
+++ b/examples/text-detection/ImageReader/android/app/src/main/AndroidManifest.xml
@@ -41,6 +41,8 @@
                 android:resource="@xml/file_paths"></meta-data>
         </provider>
 
+      <!-- To use the on-device API, configure the app to automatically download the ML model to the
+      device after the app is installed from the Play Store.-->
       <meta-data
         android:name="com.google.firebase.ml.vision.DEPENDENCIES"
         android:value="ocr" />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6224978/77090251-dffb6800-69d4-11ea-8c00-3c8ffaa12383.png)

Background - 
FirebaseVisionImage.fromFilePath which I've been using doesn't have to way to specify orientation. So I've been trying to get a bitmap (which works, but again only in upright position like in FirebaseVisionImage.fromBitmap which only support upright images). and convert it into byte[] so that I can specify rotation as part of the metadata.  At this point, FirebaseVisionTextRecognizer.processImage doesn't quite error out but either doesn't detect any text or detects gibebrish like - or * occasionally. 



